### PR TITLE
Update lookup tables

### DIFF
--- a/av1/common/av1_loopfilter.c
+++ b/av1/common/av1_loopfilter.c
@@ -131,9 +131,6 @@ static const uint64_t above_64x64_txform_mask[TX_SIZES] = {
 //  00000000
 //  00000000
 static const uint64_t left_prediction_mask[BLOCK_SIZES_ALL] = {
-  0x0000000000000001ULL,  // BLOCK_2X2,
-  0x0000000000000001ULL,  // BLOCK_2X4,
-  0x0000000000000001ULL,  // BLOCK_4X2,
   0x0000000000000001ULL,  // BLOCK_4X4,
   0x0000000000000001ULL,  // BLOCK_4X8,
   0x0000000000000001ULL,  // BLOCK_8X4,
@@ -157,9 +154,6 @@ static const uint64_t left_prediction_mask[BLOCK_SIZES_ALL] = {
 
 // 64 bit mask to shift and set for each prediction size.
 static const uint64_t above_prediction_mask[BLOCK_SIZES_ALL] = {
-  0x0000000000000001ULL,  // BLOCK_2X2
-  0x0000000000000001ULL,  // BLOCK_2X4
-  0x0000000000000001ULL,  // BLOCK_4X2
   0x0000000000000001ULL,  // BLOCK_4X4
   0x0000000000000001ULL,  // BLOCK_4X8
   0x0000000000000001ULL,  // BLOCK_8X4
@@ -184,9 +178,6 @@ static const uint64_t above_prediction_mask[BLOCK_SIZES_ALL] = {
 // each 8x8 block that would be in the top left most block of the given block
 // size in the 64x64 block.
 static const uint64_t size_mask[BLOCK_SIZES_ALL] = {
-  0x0000000000000001ULL,  // BLOCK_2X2
-  0x0000000000000001ULL,  // BLOCK_2X4
-  0x0000000000000001ULL,  // BLOCK_4X2
   0x0000000000000001ULL,  // BLOCK_4X4
   0x0000000000000001ULL,  // BLOCK_4X8
   0x0000000000000001ULL,  // BLOCK_8X4
@@ -235,9 +226,6 @@ static const uint16_t above_64x64_txform_mask_uv[TX_SIZES] = {
 
 // 16 bit left mask to shift and set for each uv prediction size.
 static const uint16_t left_prediction_mask_uv[BLOCK_SIZES_ALL] = {
-  0x0001,  // BLOCK_2X2,
-  0x0001,  // BLOCK_2X4,
-  0x0001,  // BLOCK_4X2,
   0x0001,  // BLOCK_4X4,
   0x0001,  // BLOCK_4X8,
   0x0001,  // BLOCK_8X4,
@@ -261,9 +249,6 @@ static const uint16_t left_prediction_mask_uv[BLOCK_SIZES_ALL] = {
 
 // 16 bit above mask to shift and set for uv each prediction size.
 static const uint16_t above_prediction_mask_uv[BLOCK_SIZES_ALL] = {
-  0x0001,  // BLOCK_2X2
-  0x0001,  // BLOCK_2X4
-  0x0001,  // BLOCK_4X2
   0x0001,  // BLOCK_4X4
   0x0001,  // BLOCK_4X8
   0x0001,  // BLOCK_8X4
@@ -287,9 +272,6 @@ static const uint16_t above_prediction_mask_uv[BLOCK_SIZES_ALL] = {
 
 // 64 bit mask to shift and set for each uv prediction size
 static const uint16_t size_mask_uv[BLOCK_SIZES_ALL] = {
-  0x0001,  // BLOCK_2X2
-  0x0001,  // BLOCK_2X4
-  0x0001,  // BLOCK_4X2
   0x0001,  // BLOCK_4X4
   0x0001,  // BLOCK_4X8
   0x0001,  // BLOCK_8X4
@@ -1954,9 +1936,6 @@ typedef enum EDGE_DIR { VERT_EDGE = 0, HORZ_EDGE = 1, NUM_EDGE_DIRS } EDGE_DIR;
 static const uint32_t av1_prediction_masks[NUM_EDGE_DIRS][BLOCK_SIZES_ALL] = {
   // mask for vertical edges filtering
   {
-      2 - 1,   // BLOCK_2X2
-      2 - 1,   // BLOCK_2X4
-      4 - 1,   // BLOCK_4X2
       4 - 1,   // BLOCK_4X4
       4 - 1,   // BLOCK_4X8
       8 - 1,   // BLOCK_8X4
@@ -1988,9 +1967,6 @@ static const uint32_t av1_prediction_masks[NUM_EDGE_DIRS][BLOCK_SIZES_ALL] = {
   },
   // mask for horizontal edges filtering
   {
-      2 - 1,   // BLOCK_2X2
-      4 - 1,   // BLOCK_2X4
-      2 - 1,   // BLOCK_4X2
       4 - 1,   // BLOCK_4X4
       8 - 1,   // BLOCK_4X8
       4 - 1,   // BLOCK_8X4

--- a/av1/common/blockd.h
+++ b/av1/common/blockd.h
@@ -860,9 +860,6 @@ static INLINE int get_ext_tx_types(TX_SIZE tx_size, BLOCK_SIZE bs, int is_inter,
 
 static INLINE int is_rect_tx_allowed_bsize(BLOCK_SIZE bsize) {
   static const char LUT[BLOCK_SIZES_ALL] = {
-    0,  // BLOCK_2X2
-    0,  // BLOCK_2X4
-    0,  // BLOCK_4X2
     0,  // BLOCK_4X4
     1,  // BLOCK_4X8
     1,  // BLOCK_8X4

--- a/av1/common/common_data.h
+++ b/av1/common/common_data.h
@@ -30,9 +30,6 @@ extern "C" {
 static const uint8_t b_width_log2_lookup[BLOCK_SIZES_ALL] = {
   0,
   0,
-  0,
-  0,
-  0,
   1,
   1,
   1,
@@ -53,9 +50,6 @@ static const uint8_t b_width_log2_lookup[BLOCK_SIZES_ALL] = {
   IF_EXT_PARTITION(3, 5)
 };
 static const uint8_t b_height_log2_lookup[BLOCK_SIZES_ALL] = {
-  0,
-  0,
-  0,
   0,
   1,
   0,
@@ -81,9 +75,6 @@ static const uint8_t b_height_log2_lookup[BLOCK_SIZES_ALL] = {
 static const uint8_t mi_width_log2_lookup[BLOCK_SIZES_ALL] = {
   0,
   0,
-  0,
-  0,
-  0,
   1,
   1,
   1,
@@ -104,9 +95,6 @@ static const uint8_t mi_width_log2_lookup[BLOCK_SIZES_ALL] = {
   IF_EXT_PARTITION(3, 5)
 };
 static const uint8_t mi_height_log2_lookup[BLOCK_SIZES_ALL] = {
-  0,
-  0,
-  0,
   0,
   1,
   0,
@@ -131,20 +119,17 @@ static const uint8_t mi_height_log2_lookup[BLOCK_SIZES_ALL] = {
 
 /* clang-format off */
 static const uint8_t mi_size_wide[BLOCK_SIZES_ALL] = {
-  1, 1, 1, 1, 1, 2, 2, 2, 4, 4, 4, 8, 8, 8, 16, 16,
+  1, 1, 2, 2, 2, 4, 4, 4, 8, 8, 8, 16, 16,
   IF_EXT_PARTITION(16, 32, 32)  1, 4, 2, 8, 4, 16, IF_EXT_PARTITION(8, 32)
 };
 static const uint8_t mi_size_high[BLOCK_SIZES_ALL] = {
-  1, 1, 1, 1, 2, 1, 2, 4, 2, 4, 8, 4, 8, 16, 8, 16,
+  1, 2, 1, 2, 4, 2, 4, 8, 4, 8, 16, 8, 16,
   IF_EXT_PARTITION(32, 16, 32)  4, 1, 8, 2, 16, 4, IF_EXT_PARTITION(32, 8)
 };
 /* clang-format on */
 
 // Width/height lookup tables in units of various block sizes
 static const uint8_t block_size_wide[BLOCK_SIZES_ALL] = {
-  2,
-  2,
-  4,
   4,
   4,
   8,
@@ -168,9 +153,6 @@ static const uint8_t block_size_wide[BLOCK_SIZES_ALL] = {
 };
 
 static const uint8_t block_size_high[BLOCK_SIZES_ALL] = {
-  2,
-  4,
-  2,
   4,
   8,
   4,
@@ -196,9 +178,6 @@ static const uint8_t block_size_high[BLOCK_SIZES_ALL] = {
 static const uint8_t num_4x4_blocks_wide_lookup[BLOCK_SIZES_ALL] = {
   1,
   1,
-  1,
-  1,
-  1,
   2,
   2,
   2,
@@ -219,9 +198,6 @@ static const uint8_t num_4x4_blocks_wide_lookup[BLOCK_SIZES_ALL] = {
   IF_EXT_PARTITION(8, 32)
 };
 static const uint8_t num_4x4_blocks_high_lookup[BLOCK_SIZES_ALL] = {
-  1,
-  1,
-  1,
   1,
   2,
   1,
@@ -249,9 +225,6 @@ static const uint8_t num_8x8_blocks_wide_lookup[BLOCK_SIZES_ALL] = {
   1,
   1,
   1,
-  1,
-  1,
-  1,
   2,
   2,
   2,
@@ -269,9 +242,6 @@ static const uint8_t num_8x8_blocks_wide_lookup[BLOCK_SIZES_ALL] = {
   IF_EXT_PARTITION(4, 16)
 };
 static const uint8_t num_8x8_blocks_high_lookup[BLOCK_SIZES_ALL] = {
-  1,
-  1,
-  1,
   1,
   1,
   1,
@@ -299,9 +269,6 @@ static const uint8_t size_group_lookup[BLOCK_SIZES_ALL] = {
   0,
   0,
   0,
-  0,
-  0,
-  0,
   1,
   1,
   1,
@@ -322,9 +289,6 @@ static const uint8_t size_group_lookup[BLOCK_SIZES_ALL] = {
 };
 
 static const uint8_t num_pels_log2_lookup[BLOCK_SIZES_ALL] = {
-  2,
-  3,
-  3,
   4,
   5,
   5,
@@ -355,8 +319,6 @@ static const BLOCK_SIZE subsize_lookup[PARTITION_TYPES][BLOCK_SIZES_ALL] =
 #endif  // CONFIG_EXT_PARTITION_TYPES
 {
   {     // PARTITION_NONE
-    // 2X2,        2X4,           4X2,
-    BLOCK_2X2,     BLOCK_2X4,     BLOCK_4X2,
     //                            4X4
                                   BLOCK_4X4,
     // 4X8,        8X4,           8X8
@@ -380,10 +342,8 @@ static const BLOCK_SIZE subsize_lookup[PARTITION_TYPES][BLOCK_SIZES_ALL] =
     BLOCK_32X128,  BLOCK_128X32
 #endif  // CONFIG_EXT_PARTITION
   }, {  // PARTITION_HORZ
-    // 2X2,        2X4,           4X2,
-    BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     //                            4X4
-                                  BLOCK_4X2,
+                                  BLOCK_INVALID,
     // 4X8,        8X4,           8X8
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_8X4,
     // 8X16,       16X8,          16X16
@@ -405,10 +365,8 @@ static const BLOCK_SIZE subsize_lookup[PARTITION_TYPES][BLOCK_SIZES_ALL] =
     BLOCK_INVALID, BLOCK_INVALID
 #endif  // CONFIG_EXT_PARTITION
   }, {  // PARTITION_VERT
-    // 2X2,        2X4,           4X2,
-    BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     //                            4X4
-                                  BLOCK_2X4,
+                                  BLOCK_INVALID,
     // 4X8,        8X4,           8X8
     BLOCK_INVALID, BLOCK_INVALID, BLOCK_4X8,
     // 8X16,       16X8,          16X16
@@ -430,8 +388,6 @@ static const BLOCK_SIZE subsize_lookup[PARTITION_TYPES][BLOCK_SIZES_ALL] =
     BLOCK_INVALID, BLOCK_INVALID
 #endif  // CONFIG_EXT_PARTITION
   }, {  // PARTITION_SPLIT
-    // 2X2,        2X4,           4X2,
-    BLOCK_INVALID, BLOCK_INVALID, BLOCK_INVALID,
     //                            4X4
                                   BLOCK_INVALID,
     // 4X8,        8X4,           8X8
@@ -610,8 +566,6 @@ static const BLOCK_SIZE subsize_lookup[PARTITION_TYPES][BLOCK_SIZES_ALL] =
 };
 
 static const TX_SIZE max_txsize_lookup[BLOCK_SIZES_ALL] = {
-  // 2X2,    2X4,      4X2,
-  TX_4X4,    TX_4X4,   TX_4X4,
   //                   4X4
                        TX_4X4,
   // 4X8,    8X4,      8X8
@@ -648,8 +602,6 @@ static const TX_SIZE max_txsize_lookup[BLOCK_SIZES_ALL] = {
 };
 
 static const TX_SIZE max_txsize_rect_intra_lookup[BLOCK_SIZES_ALL] = {
-  // 2X2,    2X4,      4X2,
-  TX_4X4,    TX_4X4,   TX_4X4,
   //                   4X4
                        TX_4X4,
   // 4X8,    8X4,      8X8
@@ -693,8 +645,6 @@ static const TX_SIZE max_txsize_rect_intra_lookup[BLOCK_SIZES_ALL] = {
 };
 
 static const TX_SIZE max_txsize_rect_lookup[BLOCK_SIZES_ALL] = {
-  // 2X2,    2X4,      4X2,
-  TX_4X4,    TX_4X4,   TX_4X4,
   //                   4X4
                        TX_4X4,
   // 4X8,    8X4,      8X8
@@ -764,8 +714,6 @@ static const TX_TYPE_1D htx_tab[TX_TYPES] = {
 #define TXSIZE_CAT_INVALID (-1)
 
 static const int32_t intra_tx_size_cat_lookup[BLOCK_SIZES_ALL] = {
-  // 2X2,             2X4,                4X2,
-  TXSIZE_CAT_INVALID, TXSIZE_CAT_INVALID, TXSIZE_CAT_INVALID,
   //                                      4X4,
                                           TXSIZE_CAT_INVALID,
   // 4X8,             8X4,                8X8,
@@ -1067,12 +1015,9 @@ static const TX_SIZE tx_mode_to_biggest_tx_size[TX_MODES] = {
 static const BLOCK_SIZE ss_size_lookup[BLOCK_SIZES_ALL][2][2] = {
   //  ss_x == 0    ss_x == 0        ss_x == 1      ss_x == 1
   //  ss_y == 0    ss_y == 1        ss_y == 0      ss_y == 1
-  { { BLOCK_2X2, BLOCK_INVALID }, { BLOCK_INVALID, BLOCK_INVALID } },
-  { { BLOCK_2X4, BLOCK_INVALID }, { BLOCK_INVALID, BLOCK_INVALID } },
-  { { BLOCK_4X2, BLOCK_INVALID }, { BLOCK_INVALID, BLOCK_INVALID } },
-  { { BLOCK_4X4, BLOCK_4X2 }, { BLOCK_2X4, BLOCK_2X2 } },
-  { { BLOCK_4X8, BLOCK_4X4 }, { BLOCK_INVALID, BLOCK_2X4 } },
-  { { BLOCK_8X4, BLOCK_INVALID }, { BLOCK_4X4, BLOCK_4X2 } },
+  { { BLOCK_4X4, BLOCK_4X4 }, { BLOCK_4X4, BLOCK_4X4 } },
+  { { BLOCK_4X8, BLOCK_4X4 }, { BLOCK_INVALID, BLOCK_4X4 } },
+  { { BLOCK_8X4, BLOCK_INVALID }, { BLOCK_4X4, BLOCK_4X4 } },
   { { BLOCK_8X8, BLOCK_8X4 }, { BLOCK_4X8, BLOCK_4X4 } },
   { { BLOCK_8X16, BLOCK_8X8 }, { BLOCK_INVALID, BLOCK_4X8 } },
   { { BLOCK_16X8, BLOCK_INVALID }, { BLOCK_8X8, BLOCK_8X4 } },
@@ -1103,78 +1048,6 @@ static const BLOCK_SIZE ss_size_lookup[BLOCK_SIZES_ALL][2][2] = {
 static const TX_SIZE uv_txsize_lookup[BLOCK_SIZES_ALL][TX_SIZES_ALL][2][2] = {
   //  ss_x == 0    ss_x == 0        ss_x == 1      ss_x == 1
   //  ss_y == 0    ss_y == 1        ss_y == 0      ss_y == 1
-  {
-      // BLOCK_2x2
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-#if CONFIG_TX64X64
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-#endif  // CONFIG_TX64X64
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-#if CONFIG_TX64X64
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-#endif  // CONFIG_TX64X64
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-  },
-  {
-      // BLOCK_2X4
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-#if CONFIG_TX64X64
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-#endif  // CONFIG_TX64X64
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-#if CONFIG_TX64X64
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-#endif  // CONFIG_TX64X64
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-  },
-  {
-      // BLOCK_4X2
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-#if CONFIG_TX64X64
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-#endif  // CONFIG_TX64X64
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-#if CONFIG_TX64X64
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-#endif  // CONFIG_TX64X64
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-      { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
-  },
   {
       // BLOCK_4X4
       { { TX_4X4, TX_4X4 }, { TX_4X4, TX_4X4 } },
@@ -1758,9 +1631,6 @@ static const struct {
   PARTITION_CONTEXT left;
 } partition_context_lookup[BLOCK_SIZES_ALL] = {
 #if CONFIG_EXT_PARTITION
-  { 31, 31 },  // 2X2   - {0b11111, 0b11111}
-  { 31, 31 },  // 2X4   - {0b11111, 0b11111}
-  { 31, 31 },  // 4X2   - {0b11111, 0b11111}
   { 31, 31 },  // 4X4   - {0b11111, 0b11111}
   { 31, 30 },  // 4X8   - {0b11111, 0b11110}
   { 30, 31 },  // 8X4   - {0b11110, 0b11111}
@@ -1787,9 +1657,6 @@ static const struct {
   { 24, 0 },   // 32X128- {0b11000, 0b00000}
   { 0, 24 },   // 128X32- {0b00000, 0b11000}
 #else
-  { 15, 15 },  // 2X2   - {0b1111, 0b1111}
-  { 15, 15 },  // 2X4   - {0b1111, 0b1111}
-  { 15, 15 },  // 4X2   - {0b1111, 0b1111}
   { 15, 15 },  // 4X4   - {0b1111, 0b1111}
   { 15, 14 },  // 4X8   - {0b1111, 0b1110}
   { 14, 15 },  // 8X4   - {0b1110, 0b1111}

--- a/av1/common/entropymode.c
+++ b/av1/common/entropymode.c
@@ -726,8 +726,7 @@ static const aom_cdf_prob
 
 static const aom_cdf_prob
     default_compound_type_cdf[BLOCK_SIZES_ALL][CDF_SIZE(COMPOUND_TYPES)] = {
-      { AOM_CDF3(16384, 24576) }, { AOM_CDF3(16384, 24576) },
-      { AOM_CDF3(16384, 24576) }, { AOM_CDF3(16384, 24576) },
+      { AOM_CDF3(16384, 24576) },
       { AOM_CDF3(32640, 32704) }, { AOM_CDF3(32640, 32704) },
       { AOM_CDF3(8448, 13293) },  { AOM_CDF3(9216, 12436) },
       { AOM_CDF3(10112, 12679) }, { AOM_CDF3(9088, 10753) },
@@ -763,7 +762,6 @@ static const aom_cdf_prob
 static const aom_cdf_prob
     default_wedge_interintra_cdf[BLOCK_SIZES_ALL][CDF_SIZE(2)] = {
       { AOM_CDF2(128 * 128) }, { AOM_CDF2(128 * 128) }, { AOM_CDF2(128 * 128) },
-      { AOM_CDF2(128 * 128) }, { AOM_CDF2(128 * 128) }, { AOM_CDF2(128 * 128) },
       { AOM_CDF2(194 * 128) }, { AOM_CDF2(213 * 128) }, { AOM_CDF2(217 * 128) },
       { AOM_CDF2(222 * 128) }, { AOM_CDF2(224 * 128) }, { AOM_CDF2(226 * 128) },
       { AOM_CDF2(220 * 128) }, { AOM_CDF2(128 * 128) }, { AOM_CDF2(128 * 128) },
@@ -784,7 +782,7 @@ const aom_tree_index av1_motion_mode_tree[TREE_SIZE(MOTION_MODES)] = {
 
 static const aom_prob
     default_motion_mode_prob[BLOCK_SIZES_ALL][MOTION_MODES - 1] = {
-      { 128, 128 }, { 128, 128 }, { 128, 128 }, { 128, 128 },
+      { 128, 128 },
       { 128, 128 }, { 128, 128 }, { 62, 115 },  { 39, 131 },
       { 39, 132 },  { 118, 94 },  { 77, 125 },  { 100, 121 },
       { 190, 66 },  { 207, 102 }, { 197, 100 }, { 239, 76 },
@@ -799,8 +797,7 @@ static const aom_prob
     };
 static const aom_cdf_prob
     default_motion_mode_cdf[BLOCK_SIZES_ALL][CDF_SIZE(MOTION_MODES)] = {
-      { AOM_CDF3(16384, 24576) }, { AOM_CDF3(16384, 24576) },
-      { AOM_CDF3(16384, 24576) }, { AOM_CDF3(16384, 24576) },
+      { AOM_CDF3(16384, 24576) },
       { AOM_CDF3(16384, 24576) }, { AOM_CDF3(16384, 24576) },
       { AOM_CDF3(7936, 19091) },  { AOM_CDF3(4991, 19205) },
       { AOM_CDF3(4992, 19314) },  { AOM_CDF3(15104, 21590) },
@@ -820,7 +817,6 @@ static const aom_cdf_prob
     };
 
 static const aom_cdf_prob default_obmc_cdf[BLOCK_SIZES_ALL][CDF_SIZE(2)] = {
-  { AOM_CDF2(128 * 128) }, { AOM_CDF2(128 * 128) }, { AOM_CDF2(128 * 128) },
   { AOM_CDF2(128 * 128) }, { AOM_CDF2(128 * 128) }, { AOM_CDF2(128 * 128) },
   { AOM_CDF2(45 * 128) },  { AOM_CDF2(79 * 128) },  { AOM_CDF2(75 * 128) },
   { AOM_CDF2(130 * 128) }, { AOM_CDF2(141 * 128) }, { AOM_CDF2(144 * 128) },

--- a/av1/common/enums.h
+++ b/av1/common/enums.h
@@ -139,9 +139,6 @@ typedef enum BITSTREAM_PROFILE {
 // type, so that we can save memory when they are used in structs/arrays.
 
 typedef enum ATTRIBUTE_PACKED {
-  BLOCK_2X2,
-  BLOCK_2X4,
-  BLOCK_4X2,
   BLOCK_4X4,
   BLOCK_4X8,
   BLOCK_8X4,

--- a/av1/common/reconinter.c
+++ b/av1/common/reconinter.c
@@ -244,9 +244,6 @@ const wedge_params_type wedge_params_lookup[BLOCK_SIZES_ALL] = {
   { 0, NULL, NULL, 0, NULL },
   { 0, NULL, NULL, 0, NULL },
   { 0, NULL, NULL, 0, NULL },
-  { 0, NULL, NULL, 0, NULL },
-  { 0, NULL, NULL, 0, NULL },
-  { 0, NULL, NULL, 0, NULL },
   { 4, wedge_codebook_16_heqw, wedge_signflip_lookup[BLOCK_8X8], 0,
     wedge_masks[BLOCK_8X8] },
   { 4, wedge_codebook_16_hgtw, wedge_signflip_lookup[BLOCK_8X16], 0,
@@ -2235,7 +2232,6 @@ static const int ii_weights1d[MAX_SB_SIZE] = {
   1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1
 };
 static int ii_size_scales[BLOCK_SIZES_ALL] = {
-    32, 32, 32,
     32, 16, 16, 16, 8, 8, 8, 4,
     4,  4,  2,  2,  2, 1, 1, 1,
     16, 16, 8, 8, 4, 4, 2, 2
@@ -2248,7 +2244,6 @@ static const int ii_weights1d[MAX_SB_SIZE] = {
   2,  2,  2,  2,  2,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1
 };
 static int ii_size_scales[BLOCK_SIZES_ALL] = {
-    16, 16, 16,
     16, 8, 8, 8, 4, 4, 4,
     2,  2, 2, 1, 1, 1,
     8, 8, 4, 4, 2, 2,

--- a/av1/common/reconintra.c
+++ b/av1/common/reconintra.c
@@ -407,8 +407,6 @@ static const uint16_t orders_vert_8x8[256] = {
 #if CONFIG_EXT_PARTITION
 /* clang-format off */
 static const uint16_t *const orders[BLOCK_SIZES_ALL] = {
-  // 2X2,         2X4,            4X2
-  NULL,           NULL,           NULL,
   //                              4X4
                                   orders_4x4,
   // 4X8,         8X4,            8X8
@@ -441,8 +439,6 @@ static const uint16_t *const orders[BLOCK_SIZES_ALL] = {
 #else
 /* clang-format off */
 static const uint16_t *const orders[BLOCK_SIZES_ALL] = {
-  // 2X2,         2X4,            4X2
-  NULL,           NULL,           NULL,
   //                              4X4
                                   orders_8x8,
   // 4X8,         8X4,            8X8

--- a/av1/encoder/encodeframe.c
+++ b/av1/encoder/encodeframe.c
@@ -159,9 +159,6 @@ static const uint8_t num_16x16_blocks_wide_lookup[BLOCK_SIZES_ALL] = {
   1,
   1,
   1,
-  1,
-  1,
-  1,
   2,
   2,
   2,
@@ -176,9 +173,6 @@ static const uint8_t num_16x16_blocks_wide_lookup[BLOCK_SIZES_ALL] = {
   IF_EXT_PARTITION(2, 8)
 };
 static const uint8_t num_16x16_blocks_high_lookup[BLOCK_SIZES_ALL] = {
-  1,
-  1,
-  1,
   1,
   1,
   1,
@@ -2016,7 +2010,6 @@ static void rd_use_partition(AV1_COMP *cpi, ThreadData *td,
 
 /* clang-format off */
 static const BLOCK_SIZE min_partition_size[BLOCK_SIZES_ALL] = {
-  BLOCK_2X2,   BLOCK_2X2,   BLOCK_2X2,    //    2x2,    2x4,     4x2
                             BLOCK_4X4,    //                     4x4
   BLOCK_4X4,   BLOCK_4X4,   BLOCK_4X4,    //    4x8,    8x4,     8x8
   BLOCK_4X4,   BLOCK_4X4,   BLOCK_8X8,    //   8x16,   16x8,   16x16
@@ -2033,7 +2026,6 @@ static const BLOCK_SIZE min_partition_size[BLOCK_SIZES_ALL] = {
 };
 
 static const BLOCK_SIZE max_partition_size[BLOCK_SIZES_ALL] = {
-  BLOCK_4X4,     BLOCK_4X4,       BLOCK_4X4,    //    2x2,    2x4,     4x2
                                   BLOCK_8X8,    //                     4x4
   BLOCK_16X16,   BLOCK_16X16,   BLOCK_16X16,    //    4x8,    8x4,     8x8
   BLOCK_32X32,   BLOCK_32X32,   BLOCK_32X32,    //   8x16,   16x8,   16x16
@@ -2051,7 +2043,6 @@ static const BLOCK_SIZE max_partition_size[BLOCK_SIZES_ALL] = {
 
 // Next square block size less or equal than current block size.
 static const BLOCK_SIZE next_square_size[BLOCK_SIZES_ALL] = {
-  BLOCK_2X2,   BLOCK_2X2,     BLOCK_2X2,    //    2x2,    2x4,     4x2
                               BLOCK_4X4,    //                     4x4
   BLOCK_4X4,   BLOCK_4X4,     BLOCK_8X8,    //    4x8,    8x4,     8x8
   BLOCK_8X8,   BLOCK_8X8,     BLOCK_16X16,  //   8x16,   16x8,   16x16

--- a/av1/encoder/rd.c
+++ b/av1/encoder/rd.c
@@ -54,7 +54,7 @@
 // This table is used to correct for block size.
 // The factors here are << 2 (2 = x0.5, 32 = x8 etc).
 static const uint8_t rd_thresh_block_size_factor[BLOCK_SIZES_ALL] = {
-  2,  2,  2,  2, 3,  3,  4, 6, 6, 8, 12, 12, 16, 24, 24, 32,
+  2, 3,  3,  4, 6, 6, 8, 12, 12, 16, 24, 24, 32,
 #if CONFIG_EXT_PARTITION
   48, 48, 64,
 #endif  // CONFIG_EXT_PARTITION

--- a/av1/encoder/rdopt.c
+++ b/av1/encoder/rdopt.c
@@ -4614,7 +4614,7 @@ static int find_tx_size_rd_records(MACROBLOCK *x, BLOCK_SIZE bsize, int mi_row,
 
 static const uint32_t skip_pred_threshold[3][BLOCK_SIZES_ALL] = {
   {
-      0,  0,  0,  50, 50, 50, 55, 47, 47, 53, 53, 53, 0, 0, 0, 0,
+      50, 50, 50, 55, 47, 47, 53, 53, 53, 0, 0, 0, 0,
 #if CONFIG_EXT_PARTITION
       0,  0,  0,
 #endif
@@ -4624,7 +4624,7 @@ static const uint32_t skip_pred_threshold[3][BLOCK_SIZES_ALL] = {
 #endif
   },
   {
-      0,  0,  0,  69, 69, 69, 67, 68, 68, 53, 53, 53, 0, 0, 0, 0,
+      69, 69, 69, 67, 68, 68, 53, 53, 53, 0, 0, 0, 0,
 #if CONFIG_EXT_PARTITION
       0,  0,  0,
 #endif
@@ -4634,7 +4634,7 @@ static const uint32_t skip_pred_threshold[3][BLOCK_SIZES_ALL] = {
 #endif
   },
   {
-      0,  0,  0,  70, 73, 73, 70, 73, 73, 58, 58, 58, 0, 0, 0, 0,
+      70, 73, 73, 70, 73, 73, 58, 58, 58, 0, 0, 0, 0,
 #if CONFIG_EXT_PARTITION
       0,  0,  0,
 #endif


### PR DESCRIPTION
Remove all entries for BLOCK_2X2, BLOCK_4X2, and BLOCK_2X2 in the lookup tables
with [BLOCK_SIZES_ALL] size.