### PR TITLE
Another way of adding wrapper function for aom_read_symbol_()

### DIFF
--- a/aom_dsp/daalaboolreader.c
+++ b/aom_dsp/daalaboolreader.c
@@ -35,3 +35,12 @@ uint32_t aom_daala_reader_tell(const daala_reader *r) {
 uint32_t aom_daala_reader_tell_frac(const daala_reader *r) {
   return od_ec_dec_tell_frac(&r->ec);
 }
+
+typedef struct daala_reader aom_reader;
+
+int aom_read_symbol_for_rav1e(aom_reader *r, aom_cdf_prob *cdf, int nsymbs) {
+  int ret;
+  ret = daala_read_symbol(r, cdf, nsymbs );
+  if (r->allow_update_cdf) update_cdf(cdf, ret, nsymbs);
+  return ret;
+}

--- a/aom_dsp/daalaboolreader.h
+++ b/aom_dsp/daalaboolreader.h
@@ -149,6 +149,10 @@ static INLINE int daala_read_symbol(daala_reader *r, const aom_cdf_prob *cdf,
   return symb;
 }
 
+typedef struct daala_reader aom_reader;
+
+int aom_read_symbol_for_rav1e(aom_reader *r, aom_cdf_prob *cdf, int nsymbs);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif


### PR DESCRIPTION
Will be used later with tests for adaptive EC.