### PR TITLE
Fix rav1e linking issue with Paeth predictor

### DIFF
--- a/aom_dsp/intrapred.c
+++ b/aom_dsp/intrapred.c
@@ -195,7 +195,7 @@ static INLINE uint16_t paeth_predictor_single(uint16_t left, uint16_t top,
              : (p_top <= p_top_left) ? top : top_left;
 }
 
-static INLINE void paeth_predictor(uint8_t *dst, ptrdiff_t stride, int bw,
+void paeth_predictor(uint8_t *dst, ptrdiff_t stride, int bw,
                                    int bh, const uint8_t *above,
                                    const uint8_t *left) {
   int r, c;


### PR DESCRIPTION
Removed `static INLINE` in order to call `highdb_paeth_predictor` during rav1e test runs.